### PR TITLE
Fix/normilize resource with multiple actions

### DIFF
--- a/src/tagth/tagth.py
+++ b/src/tagth/tagth.py
@@ -1,6 +1,6 @@
 from pyparsing import (
     Empty, identchars, identbodychars,
-    Literal, OneOrMore, ParseException,
+    Literal, OneOrMore, ParseException, delimitedList,
     StringEnd, Suppress, Word,
     ZeroOrMore,)
 
@@ -51,7 +51,7 @@ def _normalize_resource(resource: str) -> list[tuple[str, str]]:
     separator = Literal(TAG_LIST_DELIMETER)
     resource_tag = (Word(identchars, identbodychars))('resource_tag')
     action = (Word(identchars, identbodychars))('action')
-    actions = OneOrMore((action + Suppress((TAG_LIST_DELIMETER)) + action))('actions')
+    actions = delimitedList(action, delim=TAG_LIST_DELIMETER)('actions')
 
     single_action_module = (resource_tag + Suppress(ACTION_DELIMETER) + action).setParseAction(
         lambda t: (t.resource_tag, t.action)

--- a/src/tagth/tagth.py
+++ b/src/tagth/tagth.py
@@ -1,9 +1,15 @@
 from pyparsing import (
-    Empty, identchars, identbodychars,
-    Literal, OneOrMore, ParseException, delimitedList,
-    StringEnd, Suppress, Word,
-    ZeroOrMore,)
-
+    Empty,
+    Literal,
+    ParseException,
+    StringEnd,
+    Suppress,
+    Word,
+    ZeroOrMore,
+    delimitedList,
+    identbodychars,
+    identchars,
+)
 
 TAG_LIST_DELIMETER = ','
 ACTION_DELIMETER = ':'

--- a/test/test_normalize_principal.py
+++ b/test/test_normalize_principal.py
@@ -1,7 +1,8 @@
-import pytest
 import re
 
-from tagth.tagth import _normalize_principal, TagthValidationError
+import pytest
+
+from tagth.tagth import TagthValidationError, _normalize_principal
 
 
 def test_valid_tags():

--- a/test/test_normalize_principal.py
+++ b/test/test_normalize_principal.py
@@ -1,8 +1,7 @@
+import pytest
 import re
 
-import pytest
-
-from tagth.tagth import TagthValidationError, _normalize_principal
+from tagth.tagth import _normalize_principal, TagthValidationError
 
 
 def test_valid_tags():

--- a/test/test_normalize_resource.py
+++ b/test/test_normalize_resource.py
@@ -1,7 +1,7 @@
 import pytest
 import re
 
-from tagth.tagth import _normalize_resource, TagthValidationError
+from tagth.tagth import _normalize_resource, TagthValidationError, validate_resource
 
 
 def test_valid_resource():
@@ -175,6 +175,20 @@ def test_multiple_actions_for_one_resource():
         ('resource_tag_1', 'action_2'),
     ]
 
+    r = _normalize_resource('resource_tag:{action_1, action_2, action_3}')
+    assert r == [('resource_tag', 'action_1'), ('resource_tag', 'action_2'), ('resource_tag', 'action_3')]
+
+    r = _normalize_resource('resource_tag_1:{action_1, action_2, action_3}, resource_tag_2:{action_4, action_5, action_6, action_7}')
+    assert r == [
+        ('resource_tag_1', 'action_1'),
+        ('resource_tag_1', 'action_2'),
+        ('resource_tag_1', 'action_3'),
+        ('resource_tag_2', 'action_4'),
+        ('resource_tag_2', 'action_5'),
+        ('resource_tag_2', 'action_6'),
+        ('resource_tag_2', 'action_7')
+    ]
+
 
 def test_invalid_multiple_actions_and_empty_tag():
     with pytest.raises(TagthValidationError):
@@ -267,3 +281,9 @@ def test_single_brace():
 
     with pytest.raises(TagthValidationError):
         _normalize_resource('p1:{a1, {p2:{a3, a4}, s1}}')
+
+
+def test_smt_broken():
+    questionable_resource = 'owner_creator: {read, modearte, write}'
+    r = validate_resource(questionable_resource)
+    assert r is True

--- a/test/test_normalize_resource.py
+++ b/test/test_normalize_resource.py
@@ -63,6 +63,14 @@ def test_resource_with_whitespace():
         ('void', 'all')
     ]
 
+    r = _normalize_resource('resource_tag:{action_1, action_2, action_3}, ')
+    assert r == [
+        ('resource_tag', 'action_1'),
+        ('resource_tag', 'action_2'),
+        ('resource_tag', 'action_3'),
+        ('void', 'all')
+    ]
+
 
 def test_resource_without_colon():
     with pytest.raises(TagthValidationError):
@@ -153,6 +161,18 @@ def test_multiple_actions_for_one_resource():
         ('resource_tag_3', 'action_5')
     ]
 
+    r = _normalize_resource(
+        'resource_tag_1:{action_1, action_2}, resource_tag_2: action_3, resource_tag_3:{action_4, action_5, action_6}'
+    )
+    assert r == [
+        ('resource_tag_1', 'action_1'),
+        ('resource_tag_1', 'action_2'),
+        ('resource_tag_2', 'action_3'),
+        ('resource_tag_3', 'action_4'),
+        ('resource_tag_3', 'action_5'),
+        ('resource_tag_3', 'action_6')
+    ]
+
     r = _normalize_resource('resource_tag_1:{action_1, action_2},,')
     assert r == [
         ('resource_tag_1', 'action_1'),
@@ -174,6 +194,16 @@ def test_multiple_actions_for_one_resource():
         ('resource_tag_2', 'action_3'),
         ('resource_tag_1', 'action_1'),
         ('resource_tag_1', 'action_2'),
+    ]
+
+    r = _normalize_resource(' , resource_tag_1: action_1,,resource_tag_2:{action_2, action_3,action_4}')
+    assert r == [
+        ('void', 'all'),
+        ('resource_tag_1', 'action_1'),
+        ('void', 'all'),
+        ('resource_tag_2', 'action_2'),
+        ('resource_tag_2', 'action_3'),
+        ('resource_tag_2', 'action_4'),
     ]
 
     r = _normalize_resource('resource_tag:{action_1, action_2, action_3}')

--- a/test/test_normalize_resource.py
+++ b/test/test_normalize_resource.py
@@ -255,6 +255,9 @@ def test_nested_braces():
         _normalize_resource('resource_tag: {{action_1, action_2}}')
 
     with pytest.raises(TagthValidationError):
+        _normalize_resource('resource_tag: {{action_1, action_2, action_3}}')
+
+    with pytest.raises(TagthValidationError):
         _normalize_resource('content:{read, write:{delete}}')
 
     with pytest.raises(TagthValidationError):
@@ -312,9 +315,3 @@ def test_single_brace():
 
     with pytest.raises(TagthValidationError):
         _normalize_resource('p1:{a1, {p2:{a3, a4}, s1}}')
-
-
-def test_smt_broken():
-    questionable_resource = 'owner_creator: {read, modearte, write}'
-    r = validate_resource(questionable_resource)
-    assert r is True

--- a/test/test_normalize_resource.py
+++ b/test/test_normalize_resource.py
@@ -1,7 +1,8 @@
-import pytest
 import re
 
-from tagth.tagth import _normalize_resource, TagthValidationError, validate_resource
+import pytest
+
+from tagth.tagth import TagthValidationError, _normalize_resource, validate_resource
 
 
 def test_valid_resource():


### PR DESCRIPTION
-- fixed the issue with validating resource tags containing more than two actions (e.g., resource_tag:{action_1, action_2, action_3}).
-- the bug was discovered while working with the tapgame (see adsight-app/tapgame#573)

Changes:
-- updated parser to correctly handle multiple actions
-- added tests for 2+ actions