### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix empty resource access bypass for 'v' principal

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-17 - [Internal Placeholder Collision]
+**Vulnerability:** Found that the string "void" was used both as an internal placeholder for empty/whitespace resources AND as a potential user-controlled principal string. The library's prefix-matching logic allowed a principal named "v" (or "void") to access resources with empty ACLs because "void" starts with "v".
+**Learning:** Internal sentinel values must be distinct from the domain of user inputs. Reusing a valid identifier ("void") for a special meaning is risky when coupled with broad matching rules like `startswith`.
+**Prevention:** Use characters invalid in user input (like `@` or `$`) for internal sentinel values (e.g., `@empty`), or ensure strict type checking where sentinels are objects, not strings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.2.3
+
+## Security
+
+- Fix vulnerability where 'v' principal could access empty resources.
+
 # 1.2.2
 
 ## Bugfixes

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ An action is a string that is a valid Python identifier. A superaction is an act
 
 Resource auth tag string looks like a comma-separated of colon-separarted pairs of tags and actions: `tag_one:read, tag_two:write` or multiple actions:  `tag_one:{read, write}`(tags with associated actions).
 
+If the resource auth tag string is empty or contains only whitespace, only the `root` principal is allowed access.
+
 An action is allowed for a principal if it possesses:
 * a tag that is associated with the action
 * a tag that is associated with the superaction of the action

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tagth"
-version = "1.2.2"
+version = "1.2.3"
 description = "Pure Python Stateless Tag-Based Authorization Library"
 authors = [
     { name = "Boris Resnick", email = "boris.resnick@gmail.com" }

--- a/src/tagth/tagth.py
+++ b/src/tagth/tagth.py
@@ -17,6 +17,7 @@ ANYONE_PRINCIPAL = 'anyone'
 FULL_ACCESS_ACTION = 'all'
 ROOT_PRINCIPAL = 'root'
 VOID_PRINCIPAL = 'void'
+EMPTY_RESOURCE_TAG = '@empty'
 VOID_RESOURCE = ''
 BRACE_OPEN = '{'
 BRACE_CLOSE = '}'
@@ -69,7 +70,7 @@ def _normalize_resource(resource: str) -> list[tuple[str, str]]:
         lambda t: [(t.resource_tag, act) for act in t.actions]
     )
 
-    empty_module = (Empty()).setParseAction(lambda _: [(VOID_PRINCIPAL, FULL_ACCESS_ACTION)])
+    empty_module = (Empty()).setParseAction(lambda _: [(EMPTY_RESOURCE_TAG, FULL_ACCESS_ACTION)])
 
     resource_module = single_action_module | multiple_actions_module | empty_module
 

--- a/test/test_normalize_resource.py
+++ b/test/test_normalize_resource.py
@@ -24,7 +24,7 @@ def test_empty_resource():
     assert r == []
 
     r = _normalize_resource(' ')
-    assert r == [('void', 'all')]
+    assert r == [('@empty', 'all')]
 
 
 def test_invalid_type_resource():
@@ -44,14 +44,14 @@ def test_invalid_resource_with_no_comma():
 
 def test_resource_with_whitespace():
     r = _normalize_resource(' ,content:read')
-    assert r == [('void', 'all'), ('content', 'read')]
+    assert r == [('@empty', 'all'), ('content', 'read')]
 
     r = _normalize_resource('content:read, ')
-    assert r == [('content', 'read'), ('void', 'all')]
+    assert r == [('content', 'read'), ('@empty', 'all')]
 
     r = _normalize_resource(' ,resource_tag:{action_1, action_2}')
     assert r == [
-        ('void', 'all'),
+        ('@empty', 'all'),
         ('resource_tag', 'action_1'),
         ('resource_tag', 'action_2')
     ]
@@ -60,7 +60,7 @@ def test_resource_with_whitespace():
     assert r == [
         ('resource_tag', 'action_1'),
         ('resource_tag', 'action_2'),
-        ('void', 'all')
+        ('@empty', 'all')
     ]
 
     r = _normalize_resource('resource_tag:{action_1, action_2, action_3}, ')
@@ -68,7 +68,7 @@ def test_resource_with_whitespace():
         ('resource_tag', 'action_1'),
         ('resource_tag', 'action_2'),
         ('resource_tag', 'action_3'),
-        ('void', 'all')
+        ('@empty', 'all')
     ]
 
 
@@ -122,15 +122,15 @@ def test_resource_special_values():
 def test_multiple_empty_resources():
     r = _normalize_resource(',')
     assert r == [
-        ('void', 'all'),
-        ('void', 'all'),
+        ('@empty', 'all'),
+        ('@empty', 'all'),
     ]
 
     r = _normalize_resource(', ,')
     assert r == [
-        ('void', 'all'),
-        ('void', 'all'),
-        ('void', 'all'),
+        ('@empty', 'all'),
+        ('@empty', 'all'),
+        ('@empty', 'all'),
     ]
 
 
@@ -177,20 +177,20 @@ def test_multiple_actions_for_one_resource():
     assert r == [
         ('resource_tag_1', 'action_1'),
         ('resource_tag_1', 'action_2'),
-        ('void', 'all'),
-        ('void', 'all')
+        ('@empty', 'all'),
+        ('@empty', 'all')
     ]
 
     r = _normalize_resource('resource_tag_1:{action_1, action_2}, ')
     assert r == [
         ('resource_tag_1', 'action_1'),
         ('resource_tag_1', 'action_2'),
-        ('void', 'all'),
+        ('@empty', 'all'),
     ]
 
     r = _normalize_resource(' , resource_tag_2: action_3, resource_tag_1:{action_1, action_2}')
     assert r == [
-        ('void', 'all'),
+        ('@empty', 'all'),
         ('resource_tag_2', 'action_3'),
         ('resource_tag_1', 'action_1'),
         ('resource_tag_1', 'action_2'),
@@ -198,9 +198,9 @@ def test_multiple_actions_for_one_resource():
 
     r = _normalize_resource(' , resource_tag_1: action_1,,resource_tag_2:{action_2, action_3,action_4}')
     assert r == [
-        ('void', 'all'),
+        ('@empty', 'all'),
         ('resource_tag_1', 'action_1'),
-        ('void', 'all'),
+        ('@empty', 'all'),
         ('resource_tag_2', 'action_2'),
         ('resource_tag_2', 'action_3'),
         ('resource_tag_2', 'action_4'),

--- a/test/test_vulnerability_fix.py
+++ b/test/test_vulnerability_fix.py
@@ -1,0 +1,23 @@
+from tagth.tagth import allowed, _normalize_resource
+
+def test_v_principal_access_whitespace_resource():
+    # Vulnerability check:
+    # A resource with only whitespace (e.g. ' ') normalizes to [('void', 'all')]
+    # Since 'void' starts with 'v', the principal 'v' matches it.
+
+    p = 'v'
+    r = ' '
+    a = 'read'
+
+    # Before fix, this assertion fails because allowed returns True
+    # After fix, allowed should return False
+    assert not allowed(p, r, a), "Principal 'v' should NOT access whitespace resource"
+
+def test_empty_resource_behavior():
+    # Empty resource string '' currently normalizes to [].
+    # But whitespace ' ' normalizes to [('void', 'all')].
+    # This confirms the normalization that causes the issue.
+    # After fix, it should normalize to something that 'v' doesn't match.
+
+    # We can check normalization result directly if needed, but 'allowed' test covers the security impact.
+    pass


### PR DESCRIPTION
🛡️ **Sentinel Security Fix**

**Vulnerability:**
The library used the string `'void'` as an internal placeholder for resources with empty or whitespace-only tags.
The authorization logic uses prefix matching (`startswith`).
This meant any principal whose name is a prefix of `'void'` (e.g., `'v'`, `'vo'`, `'void'`) would be granted access to any resource with an empty tag string (which normalizes to `void:all`).

**Fix:**
Changed the internal constant `VOID_PRINCIPAL` usage in `_normalize_resource` to a new constant `EMPTY_RESOURCE_TAG = '@empty'`.
The `@` character is not allowed in valid principal tags (which are restricted to `A-Za-z0-9_`), making it impossible for a user to spoof or match this tag.

**Impact:**
Prevents unintended privilege escalation where a user named 'v' could access unprotected resources.
Does not affect the behavior of the special `void` principal (which is still skipped in logic), nor does it affect valid resource tags.

**Verification:**
Added reproduction test case `test/test_vulnerability_fix.py`.
Ran full test suite.


---
*PR created automatically by Jules for task [13123156946636128811](https://jules.google.com/task/13123156946636128811) started by @scartill*