### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix internal placeholder collision for void principal

### DIFF
--- a/test/test_normalize_principal.py
+++ b/test/test_normalize_principal.py
@@ -17,12 +17,12 @@ def test_valid_tags():
 
 def test_empty_tag():
     p = _normalize_principal('')
-    assert p == ['void']
+    assert p == ['@void']
 
 
 def test_whitespace_tag():
     p = _normalize_principal(' ')
-    assert p == ['void']
+    assert p == ['@void']
 
 
 def test_invalid_tag_int():
@@ -59,18 +59,18 @@ def test_not_isidentifier_tag():
 
 def test_with_whitespaces():
     p = _normalize_principal('tag_1, tag_2, ')
-    assert p == ['tag_1', 'tag_2', 'void']
+    assert p == ['tag_1', 'tag_2', '@void']
 
     p = _normalize_principal(' ,tag_1')
-    assert p == ['void', 'tag_1']
+    assert p == ['@void', 'tag_1']
 
     p = _normalize_principal(' , ')
-    assert p == ['void', 'void']
+    assert p == ['@void', '@void']
 
     p = _normalize_principal(',')
-    assert p == ['void', 'void']
+    assert p == ['@void', '@void']
 
 
 def test_with_multiple_commas():
     p = _normalize_principal('tag_1,,,tag_2')
-    assert p == ['tag_1', 'void', 'void', 'tag_2']
+    assert p == ['tag_1', '@void', '@void', 'tag_2']

--- a/test/test_tagth.py
+++ b/test/test_tagth.py
@@ -104,7 +104,7 @@ def test_void():
     assert a
 
     a = allowed('void', 'void:all', 'action')
-    assert not a
+    assert a
 
 
 def test_empty_anyone():


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix internal placeholder collision for void principal

* 🚨 Severity: MEDIUM
* 💡 Vulnerability: The string "void" was used both as an internal placeholder for empty principals and as a valid user-controlled principal string. This caused a collision where a legitimate user named "void" was treated as unauthenticated.
* 🎯 Impact: Users with the principal name "void" were denied access to resources they should have access to.
* 🔧 Fix: Introduced `INTERNAL_VOID_PRINCIPAL = '@void'` as a distinct internal sentinel. Updated logic to use this sentinel, allowing "void" to be a regular user tag. Also fixed `pyparsing` DeprecationWarnings.
* ✅ Verification: Ran `pytest` suite. Verified that `test_void` now passes with `True` (access granted), and empty inputs still result in no access (except `anyone`).

---
*PR created automatically by Jules for task [16394627061773711509](https://jules.google.com/task/16394627061773711509) started by @scartill*