### PR TITLE
🛡️ Sentinel: Fix Authorization Bypass via Prefix Matching

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Found that the string "void" was used both as an internal placeholder for empty/whitespace resources AND as a potential user-controlled principal string. The library's prefix-matching logic allowed a principal named "v" (or "void") to access resources with empty ACLs because "void" starts with "v".
 **Learning:** Internal sentinel values must be distinct from the domain of user inputs. Reusing a valid identifier ("void") for a special meaning is risky when coupled with broad matching rules like `startswith`.
 **Prevention:** Use characters invalid in user input (like `@` or `$`) for internal sentinel values (e.g., `@empty`), or ensure strict type checking where sentinels are objects, not strings.
+
+## 2025-05-15 - [Broad Prefix Authorization Bypass]
+**Vulnerability:** The library used `startswith()` for tag matching, allowing a principal `user` to access resources tagged `username`, `user_admin`, or `users`. This unintentional "supertag" behavior violated the principle of least privilege.
+**Learning:** Prefix matching without delimiters is inherently ambiguous and insecure for authorization. It creates overlapping namespaces where short tags accidentally grant access to longer, unrelated tags.
+**Prevention:** Always enforce a delimiter (e.g., `_` or `:`) or require exact matches for authorization tags. Use strict matching logic: `tag == target OR tag.startswith(target + delimiter)`.

--- a/src/tagth/tagth.py
+++ b/src/tagth/tagth.py
@@ -83,6 +83,14 @@ def _normalize_resource(resource: str) -> list[tuple[str, str]]:
         raise TagthValidationError(f"Invalid resource: {resource}") from e
 
 
+def _is_supertag(tag: str, supertag: str) -> bool:
+    """Checks if a tag is a supertag of another tag.
+
+    A supertag is a prefix of another tag, followed by an underscore or exact match.
+    """
+    return tag == supertag or tag.startswith(supertag + '_')
+
+
 def _resolve_internal(principal: list[str], resource: list[tuple[str, str]]) -> set[str]:
     actions = set()
 
@@ -102,7 +110,7 @@ def _resolve_internal(principal: list[str], resource: list[tuple[str, str]]) -> 
             continue
 
         for (res_tag, action) in resource:
-            if res_tag.startswith(pr_tag):
+            if _is_supertag(res_tag, pr_tag):
                 actions.add(action)
 
     return actions
@@ -131,7 +139,7 @@ def allowed(principal: str, resource: str, action: str) -> bool:
         return True
 
     for allowed_action in actions:
-        if action.startswith(allowed_action):
+        if _is_supertag(action, allowed_action):
             return True
 
     return False

--- a/test/test_resolve.py
+++ b/test/test_resolve.py
@@ -83,12 +83,12 @@ def test_with_matching_tags():
     p = 'me'
     r = 'meme_me:all'
     a = _resolve(p, r)
-    assert a == {'all'}
+    assert a == set()
 
     p = 'me'
     r = 'xmememe:ro, meme:rw'
     a = _resolve(p, r)
-    assert a == {'rw'}
+    assert a == set()
 
     p = 'admin, user'
     r = 'admin:write, user:read'

--- a/test/test_security_fixes.py
+++ b/test/test_security_fixes.py
@@ -1,0 +1,57 @@
+from tagth.tagth import allowed, _resolve
+
+def test_strict_prefix_matching_principal_resource():
+    # Verify that 'me' does NOT match 'meme'
+    p = 'me'
+    r = 'meme:read'
+    assert _resolve(p, r) == set()
+    assert not allowed(p, r, 'read')
+
+    # Verify that 'me' DOES match 'me'
+    p = 'me'
+    r = 'me:read'
+    assert _resolve(p, r) == {'read'}
+    assert allowed(p, r, 'read')
+
+    # Verify that 'me' DOES match 'me_stuff'
+    p = 'me'
+    r = 'me_stuff:read'
+    assert _resolve(p, r) == {'read'}
+    assert allowed(p, r, 'read')
+
+    # Verify that 'admin' DOES match 'admin_user'
+    p = 'admin'
+    r = 'admin_user:read'
+    assert _resolve(p, r) == {'read'}
+    assert allowed(p, r, 'read')
+
+    # Verify that 'admin' does NOT match 'administrator'
+    p = 'admin'
+    r = 'administrator:read'
+    assert _resolve(p, r) == set()
+    assert not allowed(p, r, 'read')
+
+
+def test_strict_prefix_matching_action():
+    # Verify that 'up' does NOT match 'update'
+    p = 'user'
+    r = 'user:up'
+    # allowed(p, r, 'update')
+    # principal 'user' has access to action 'up'.
+    # Does 'up' grant 'update'? No.
+    assert not allowed(p, r, 'update')
+
+    # Verify that 'update' DOES match 'update_password' (standard hierarchy with underscore)
+    r = 'user:update'
+    assert allowed(p, r, 'update_password')
+
+    # Verify that 'read' does NOT match 'reader'
+    r = 'user:read'
+    assert not allowed(p, r, 'reader')
+
+    # Verify that 'create' DOES match 'create_asset' (superaction with underscore)
+    r = 'user:create'
+    assert allowed(p, r, 'create_asset')
+
+    # Verify that 'create' DOES match 'create'
+    assert allowed(p, r, 'create')

--- a/test/test_tagth.py
+++ b/test/test_tagth.py
@@ -25,16 +25,16 @@ def test_resolve():
     assert r == {'all'}
 
     r = _resolve('me', 'meme_me:all')
-    assert r == {'all'}
+    assert r == set()
 
     r = _resolve('mememe', 'me:all')
     assert r == set()
 
     r = _resolve('me', 'mememe:ro, meme:rw')
-    assert r == {'ro', 'rw'}
+    assert r == set()
 
     r = _resolve('me', 'xmememe:ro, meme:rw')
-    assert r == {'rw'}
+    assert r == set()
 
 
 def test_allowed():
@@ -51,7 +51,7 @@ def test_allowed():
     assert a
 
     a = allowed('me', 'they:ro, meme:rw', 'rw')
-    assert a
+    assert not a
 
     a = allowed('me', 'ther:ro, meme:rw', 'ro')
     assert not a
@@ -84,10 +84,10 @@ def test_empty_principal():
     assert not a
 
     a = allowed(',res', 'resource:all', 'action')
-    assert a
+    assert not a
 
     a = allowed(',res', 'other:all,resource:all', 'action')
-    assert a
+    assert not a
 
     a = allowed('other,another', 'other:all,resource:all', 'action')
     assert a


### PR DESCRIPTION
Implemented strict prefix matching using `_is_supertag` helper to prevent unintended authorization grants. Updated tests to reflect secure behavior and added new security tests.

---
*PR created automatically by Jules for task [18015108167712568203](https://jules.google.com/task/18015108167712568203) started by @scartill*