### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix privilege escalation for the `all` action

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,3 +1,13 @@
+## 2025-02-17 - [Internal Placeholder Collision]
+**Vulnerability:** Found that the string "void" was used both as an internal placeholder for empty/whitespace resources AND as a potential user-controlled principal string. The library's prefix-matching logic allowed a principal named "v" (or "void") to access resources with empty ACLs because "void" starts with "v".
+**Learning:** Internal sentinel values must be distinct from the domain of user inputs. Reusing a valid identifier ("void") for a special meaning is risky when coupled with broad matching rules like `startswith`.
+**Prevention:** Use characters invalid in user input (like `@` or `$`) for internal sentinel values (e.g., `@empty`), or ensure strict type checking where sentinels are objects, not strings.
+
+## 2025-02-18 - [Intended Insecure Prefix Matching]
+**Vulnerability:** Identified that the library uses loose string prefix matching (e.g., `admin` matches `administrator`), which can lead to unintended privilege escalation if tag names are not chosen carefully.
+**Learning:** This behavior is an **intended feature** of the library, not a bug to be fixed by code changes. The library relies on simple `startswith` logic for "supertags".
+**Prevention:** Do NOT attempt to change the matching logic to be stricter (e.g., delimiter-based). Instead, document this behavior clearly so users can design their tag schemas accordingly (e.g., avoiding overlapping prefixes for distinct roles).
+
 ## 2024-05-18 - [Privilege Escalation via Prefix Matching of Special Actions]
 **Vulnerability:** A user granted an action tag that is a prefix of a special internal action like `all` (e.g., `a` or `al`) is erroneously granted full system access because the authorization library evaluates `action.startswith(allowed_action)`.
 **Learning:** When using prefix-based string matching for authorization tags or actions, special values that represent full access (e.g., `all`, `*`) must be explicitly excluded from being matched as a suffix to a user's tag.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,9 +1,4 @@
-## 2025-02-17 - [Internal Placeholder Collision]
-**Vulnerability:** Found that the string "void" was used both as an internal placeholder for empty/whitespace resources AND as a potential user-controlled principal string. The library's prefix-matching logic allowed a principal named "v" (or "void") to access resources with empty ACLs because "void" starts with "v".
-**Learning:** Internal sentinel values must be distinct from the domain of user inputs. Reusing a valid identifier ("void") for a special meaning is risky when coupled with broad matching rules like `startswith`.
-**Prevention:** Use characters invalid in user input (like `@` or `$`) for internal sentinel values (e.g., `@empty`), or ensure strict type checking where sentinels are objects, not strings.
-
-## 2025-02-18 - [Intended Insecure Prefix Matching]
-**Vulnerability:** Identified that the library uses loose string prefix matching (e.g., `admin` matches `administrator`), which can lead to unintended privilege escalation if tag names are not chosen carefully.
-**Learning:** This behavior is an **intended feature** of the library, not a bug to be fixed by code changes. The library relies on simple `startswith` logic for "supertags".
-**Prevention:** Do NOT attempt to change the matching logic to be stricter (e.g., delimiter-based). Instead, document this behavior clearly so users can design their tag schemas accordingly (e.g., avoiding overlapping prefixes for distinct roles).
+## 2024-05-18 - [Privilege Escalation via Prefix Matching of Special Actions]
+**Vulnerability:** A user granted an action tag that is a prefix of a special internal action like `all` (e.g., `a` or `al`) is erroneously granted full system access because the authorization library evaluates `action.startswith(allowed_action)`.
+**Learning:** When using prefix-based string matching for authorization tags or actions, special values that represent full access (e.g., `all`, `*`) must be explicitly excluded from being matched as a suffix to a user's tag.
+**Prevention:** Always check for an exact match against special reserved actions before falling back to prefix matching for regular actions.

--- a/src/tagth/tagth.py
+++ b/src/tagth/tagth.py
@@ -130,6 +130,9 @@ def allowed(principal: str, resource: str, action: str) -> bool:
     if FULL_ACCESS_ACTION in actions:
         return True
 
+    if action == FULL_ACCESS_ACTION:
+        return False
+
     for allowed_action in actions:
         if action.startswith(allowed_action):
             return True

--- a/test/test_vulnerability_fix.py
+++ b/test/test_vulnerability_fix.py
@@ -21,7 +21,6 @@ def test_empty_resource_behavior():
 
     # We can check normalization result directly if needed, but 'allowed' test covers the security impact.
     pass
-
 def test_all_action_privilege_escalation():
     # Vulnerability check:
     # An action prefix such as 'a' or 'al' should NOT grant the 'all' action.

--- a/test/test_vulnerability_fix.py
+++ b/test/test_vulnerability_fix.py
@@ -21,6 +21,7 @@ def test_empty_resource_behavior():
 
     # We can check normalization result directly if needed, but 'allowed' test covers the security impact.
     pass
+
 def test_all_action_privilege_escalation():
     # Vulnerability check:
     # An action prefix such as 'a' or 'al' should NOT grant the 'all' action.

--- a/test/test_vulnerability_fix.py
+++ b/test/test_vulnerability_fix.py
@@ -21,3 +21,16 @@ def test_empty_resource_behavior():
 
     # We can check normalization result directly if needed, but 'allowed' test covers the security impact.
     pass
+
+def test_all_action_privilege_escalation():
+    # Vulnerability check:
+    # An action prefix such as 'a' or 'al' should NOT grant the 'all' action.
+    # Because action.startswith(allowed_action) would be True if allowed_action='a' and action='all'
+
+    # User is granted action 'a'
+    assert not allowed("user", "user:a", "all"), "Action 'a' should NOT grant 'all' access"
+    assert not allowed("user", "user:al", "all"), "Action 'al' should NOT grant 'all' access"
+
+    # But user should be granted action 'a' and 'a_something'
+    assert allowed("user", "user:a", "a"), "Action 'a' should grant 'a' access"
+    assert allowed("user", "user:a", "a_something"), "Action 'a' should grant 'a_something' access"


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Users with short action prefixes (like `a` or `al`) were erroneously granted the `all` (FULL_ACCESS_ACTION) because `tagth` evaluates privileges using `action.startswith(allowed_action)`.
🎯 Impact: Privilege escalation. A user granted limited access to `a` could perform `all` actions.
🔧 Fix: Explicitly return `False` if the requested action is `FULL_ACCESS_ACTION` and wasn't explicitly matched earlier by `if FULL_ACCESS_ACTION in actions: return True`.
✅ Verification: Tested against `test_vulnerability_fix.py` validating that action `a` or `al` does not grant `all`.

---
*PR created automatically by Jules for task [15756241921384224888](https://jules.google.com/task/15756241921384224888) started by @scartill*