### PR TITLE
Bump version to 1.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.2.4
+
+## Routine Updates
+
+- Publish a new patch version.
+
 # 1.2.3
 
 ## Security

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tagth"
-version = "1.2.3"
+version = "1.2.4"
 description = "Pure Python Stateless Tag-Based Authorization Library"
 authors = [
     { name = "Boris Resnick", email = "boris.resnick@gmail.com" }


### PR DESCRIPTION
This PR bumps the project version from 1.2.3 to 1.2.4 and adds an entry to CHANGELOG.md as requested. Tests have been run successfully.

---
*PR created automatically by Jules for task [2430268781778777389](https://jules.google.com/task/2430268781778777389) started by @scartill*