### PR TITLE
🛡️ Sentinel: [Security Enhancement] Add type validation for action in allowed()

### DIFF
--- a/src/tagth/tagth.py
+++ b/src/tagth/tagth.py
@@ -125,6 +125,9 @@ def allowed(principal: str, resource: str, action: str) -> bool:
     Returns:
         bool: True if the action is allowed, False otherwise.
     """
+    if not isinstance(action, str):
+        raise TagthValidationError(f'Bad action {action}')
+
     actions = _resolve(principal, resource)
 
     if FULL_ACCESS_ACTION in actions:

--- a/test/test_allowed.py
+++ b/test/test_allowed.py
@@ -195,10 +195,5 @@ def test_special_format_any_and_all():
     assert allowed(p_user, r, 'all')
 
 def test_allowed_invalid_action_type():
-    import pytest
-    from tagth.tagth import TagthValidationError
-
-    with pytest.raises(TagthValidationError) as exc:
+    with pytest.raises(TagthValidationError, match="Bad action 123"):
         allowed("user", "user:read", 123)
-
-    assert "Bad action 123" in str(exc.value)

--- a/test/test_allowed.py
+++ b/test/test_allowed.py
@@ -193,3 +193,12 @@ def test_special_format_any_and_all():
     assert allowed(p_root, r, 'all')
     assert allowed(p_void, r, 'all')
     assert allowed(p_user, r, 'all')
+
+def test_allowed_invalid_action_type():
+    import pytest
+    from tagth.tagth import TagthValidationError
+
+    with pytest.raises(TagthValidationError) as exc:
+        allowed("user", "user:read", 123)
+
+    assert "Bad action 123" in str(exc.value)


### PR DESCRIPTION
This PR adds a defensive security enhancement by strictly validating the `action` argument passed to `allowed()`. Since Python's type hints do not enforce types at runtime, bad inputs (e.g., from unvalidated JSON requests) could trigger unhandled internal exceptions (`AttributeError`). This enforces secure, graceful failures.

---
*PR created automatically by Jules for task [11608310057459212313](https://jules.google.com/task/11608310057459212313) started by @scartill*