### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Exception Chaining Information Leak

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -16,3 +16,8 @@
 **Vulnerability:** Found that the `TagthValidationError` exceptions were leaking raw user input for invalid principals, resources, and actions by injecting the untrusted string into the exception message.
 **Learning:** Returning unsanitized user input in error messages is dangerous, as it can be leveraged in reflected attacks or to infer backend states if errors are surfaced to the user.
 **Prevention:** Always use static, generic strings for validation errors. Rely on application logs for detailed debugging info instead of the exception message.
+
+## 2024-05-18 - Exception Context Leakage in PyParsing Error Handling
+**Vulnerability:** Exception chaining (`from e`) when catching PyParsing's `ParseException` caused `TagthValidationError` to expose internal parser state and raw user input snippets via stack traces.
+**Learning:** Python 3's automatic exception chaining via `from e` (or implicit chaining) inadvertently exposes internal implementation details (like the underlying parser used) and can log sensitive strings if the input causing the parse error contained secrets.
+**Prevention:** Always use `raise CustomException("Generic message") from None` when wrapping internal library exceptions to ensure secure, generic error boundaries.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,7 +17,7 @@
 **Learning:** Returning unsanitized user input in error messages is dangerous, as it can be leveraged in reflected attacks or to infer backend states if errors are surfaced to the user.
 **Prevention:** Always use static, generic strings for validation errors. Rely on application logs for detailed debugging info instead of the exception message.
 
-## 2024-05-18 - Exception Context Leakage in PyParsing Error Handling
-**Vulnerability:** Exception chaining (`from e`) when catching PyParsing's `ParseException` caused `TagthValidationError` to expose internal parser state and raw user input snippets via stack traces.
-**Learning:** Python 3's automatic exception chaining via `from e` (or implicit chaining) inadvertently exposes internal implementation details (like the underlying parser used) and can log sensitive strings if the input causing the parse error contained secrets.
+## 2024-05-18 - [Exception Context Leakage in pyparsing Error Handling]
+**Vulnerability:** Exception chaining (`from e`) when catching pyparsing's `ParseException` caused `TagthValidationError` to expose internal parser state and raw user input snippets via stack traces.
+**Learning:** Python 3 exception chaining (explicit via `raise ... from e`, or implicit when raising inside an `except` block without `from None`) can expose internal implementation details and may log sensitive input snippets if present.
 **Prevention:** Always use `raise CustomException("Generic message") from None` when wrapping internal library exceptions to ensure secure, generic error boundaries.

--- a/src/tagth/tagth.py
+++ b/src/tagth/tagth.py
@@ -45,8 +45,8 @@ def _normalize_principal(principal: str) -> list[str]:
     try:
         result = parser.parseString(principal)
         return result.asList()
-    except ParseException as e:
-        raise TagthValidationError('Invalid principal format') from e
+    except ParseException:
+        raise TagthValidationError('Invalid principal format') from None
 
 
 def _normalize_resource(resource: str) -> list[tuple[str, str]]:
@@ -79,8 +79,8 @@ def _normalize_resource(resource: str) -> list[tuple[str, str]]:
     try:
         result = parser.parseString(resource)
         return result.asList()
-    except ParseException as e:
-        raise TagthValidationError('Invalid resource format') from e
+    except ParseException:
+        raise TagthValidationError('Invalid resource format') from None
 
 
 def _resolve_internal(principal: list[str], resource: list[tuple[str, str]]) -> set[str]:


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Exception chaining (`from e`) when catching PyParsing's `ParseException` caused `TagthValidationError` to expose internal parser state and raw user input snippets via stack traces.
🎯 Impact: Leaking detailed pyparsing error states or partial inputs could potentially reveal unintended context or sensitive info to users/logs if not handled properly at higher levels.
🔧 Fix: Used `raise CustomException(...) from None` to explicitly suppress the exception context and avoid trace leakages.
✅ Verification: Ran `uv run pytest test/` and `uv run ruff check` which both pass. Verified traceback outputs do not contain the underlying `pyparsing` internal stack trace or input content.

---
*PR created automatically by Jules for task [4688297488728129960](https://jules.google.com/task/4688297488728129960) started by @scartill*